### PR TITLE
Add GCS data loader for climate dataset

### DIFF
--- a/ml_logic/gcp_data_loader.py
+++ b/ml_logic/gcp_data_loader.py
@@ -1,0 +1,33 @@
+from google.cloud import storage
+import pandas as pd
+
+
+def load_climate_dataset_from_gcs(
+    bucket_name: str = "arima-models-bucket",
+    blob_path: str = "data/Q_13_previous-1950-2023_RR-T-Vent.csv.gz",
+    local_filename: str = "Q_13_previous-1950-2023_RR-T-Vent.csv.gz"
+) -> pd.DataFrame:
+    """
+    Download the compressed climate dataset from Google Cloud Storage and return it as a pandas DataFrame.
+
+    Args:
+        bucket_name (str): Name of the GCS bucket.
+        blob_path (str): Path to the blob (file) in the bucket.
+        local_filename (str): Local filename to save the downloaded file.
+
+    Returns:
+        pd.DataFrame: The loaded dataset.
+    """
+    print(f"Downloading {blob_path} from bucket {bucket_name}...")
+
+    client = storage.Client()
+    bucket = client.bucket(bucket_name)
+    blob = bucket.blob(blob_path)
+
+    blob.download_to_filename(local_filename)
+    print(f"Downloaded to {local_filename}")
+
+    df = pd.read_csv(local_filename, compression='gzip')
+    print(f"Loaded dataset with shape: {df.shape}")
+
+    return df

--- a/ml_logic/test_loader.py
+++ b/ml_logic/test_loader.py
@@ -1,0 +1,5 @@
+from gcp_data_loader import load_climate_dataset_from_gcs
+
+df = load_climate_dataset_from_gcs()
+
+print(df.head())

--- a/requirements.txt
+++ b/requirements.txt
@@ -317,3 +317,6 @@ yapf==0.32.0
 yarl==1.18.3
 ydata-profiling==4.2.0
 zipp==3.10.0
+
+# Reminder: Run `gcloud components update` to update Google Cloud CLI components.
+google-cloud-storage


### PR DESCRIPTION
- Added `gcp_data_loader.py` to load compressed .csv.gz dataset from GCS
- GCS bucket: `arima-models-bucket`
- Path: `data/Q_13_previous-1950-2023_RR-T-Vent.csv.gz`
- Tested locally with test script `test_loader.py` but havent pushed it.
- Updated `requirements.txt` to include `google-cloud-storage`